### PR TITLE
fixed error:  if variable are the output from other module

### DIFF
--- a/security_groups.tf
+++ b/security_groups.tf
@@ -23,6 +23,6 @@ resource "aws_security_group_rule" "redis_networks_ingress" {
   from_port                = "${var.redis_port}"
   to_port                  = "${var.redis_port}"
   protocol                 = "tcp"
-  cidr_blocks              = "${var.allowed_cidr}"
+  cidr_blocks              = ["${var.allowed_cidr}"]
   security_group_id        = "${aws_security_group.redis_security_group.id}"
 }


### PR DESCRIPTION
fixed error: `redis_networks_ingress: cidr_blocks: should be a list` if variable are the output from other module